### PR TITLE
Add check for OpenAI key in proxy

### DIFF
--- a/netlify/functions/openai-proxy.js
+++ b/netlify/functions/openai-proxy.js
@@ -23,6 +23,16 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    // Verificar que la API key de OpenAI esté configurada
+    if (!process.env.OPENAI_API_KEY) {
+      console.error('OpenAI API key not configured');
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({ error: 'OpenAI API key not configured' })
+      };
+    }
+
     const { responses, nombre } = JSON.parse(event.body);
     
     // Construir el prompt para OpenAI


### PR DESCRIPTION
## Summary
- check that `OPENAI_API_KEY` is present before requesting OpenAI

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685098dd1ab0832e9da55a566fa73d39